### PR TITLE
fix: support flexible flex_attn_kernel_options

### DIFF
--- a/demo/ocr_single.py
+++ b/demo/ocr_single.py
@@ -32,6 +32,7 @@ def main(
     hf_local_dir: str | None = None,
     device: str | None = None,
     dtype: Literal["bfloat16", "float", "float32"] = "float32",
+    flex_attn_safe: bool = False,
     out_dir: str = "./outputs/",
     compile: bool = True,
     cudagraph: bool = True,
@@ -39,7 +40,11 @@ def main(
     """Run Falcon OCR on a single image.
 
     If --image is omitted, a sample is loaded from OCRBench-v2.
+
+    Use --flex-attn-safe on GPUs with limited per-SM shared memory
+    (A40, RTX 3090/4090, L40) to avoid FlexAttention Triton OOM. See README.
     """
+    kernel_options = {"BLOCK_M": 64, "BLOCK_N": 64, "num_stages": 1} if flex_attn_safe else None
     model, tokenizer, model_args = load_and_prepare_model(
         hf_model_id=hf_model_id or OCR_MODEL_ID,
         hf_revision=hf_revision,
@@ -75,7 +80,7 @@ def main(
 
     image_processor = ImageProcessor(patch_size=16, merge_size=1)
 
-    engine = OCRInferenceEngine(model, tokenizer, image_processor, capture_cudagraph=cudagraph)
+    engine = OCRInferenceEngine(model, tokenizer, image_processor, capture_cudagraph=cudagraph, kernel_options=kernel_options)
 
     print("Running inference ...")
 

--- a/demo/perception_single.py
+++ b/demo/perception_single.py
@@ -42,6 +42,7 @@ def main(
     device: str | None = None,
     dtype: Literal["bfloat16", "float32", "float"] = "float32",
     engine_type: Literal["batch", "paged"] = "paged",
+    flex_attn_safe: bool = False,
     out_dir: str = "./outputs/",
     compile: bool = True,
     cudagraph: bool = True,
@@ -49,7 +50,11 @@ def main(
     """Run Falcon Perception (detection/segmentation) on a single image.
 
     If --image is omitted, a sample is streamed from the PBench dataset.
+
+    Use --flex-attn-safe on GPUs with limited per-SM shared memory
+    (A40, RTX 3090/4090, L40) to avoid FlexAttention Triton OOM. See README.
     """
+    kernel_options = {"BLOCK_M": 64, "BLOCK_N": 64, "num_stages": 1} if flex_attn_safe else {}
     model, tokenizer, model_args = load_and_prepare_model(
         hf_model_id=hf_model_id or PERCEPTION_MODEL_ID,
         hf_revision=hf_revision,
@@ -112,6 +117,7 @@ def main(
             prefill_length_limit=8192,
             enable_hr_cache=False,
             capture_cudagraph=cudagraph,
+            kernel_options=kernel_options or None,
         )
 
         prompt = build_prompt_for_task(query, task)
@@ -171,7 +177,7 @@ def main(
         from falcon_perception.visualization_utils import render_batch_inference_outputs
 
         prompt = build_prompt_for_task(query, task)
-        engine = BatchInferenceEngine(model, tokenizer)
+        engine = BatchInferenceEngine(model, tokenizer, kernel_options=kernel_options or None)
         batch_inputs = process_batch_and_generate(
             tokenizer,
             [(pil_image, prompt)],

--- a/falcon_perception/batch_inference.py
+++ b/falcon_perception/batch_inference.py
@@ -147,10 +147,11 @@ class KVCache(KVCacheBase):
 
 
 class BatchInferenceEngine:
-    def __init__(self, model: FalconPerception, tokenizer):
+    def __init__(self, model: FalconPerception, tokenizer, kernel_options: dict | None = None):
         self.model = model
         self.model_args = model.args
         self.tokenizer = tokenizer
+        self.kernel_options = kernel_options or {}
 
     def pad_input_to_max_length(self, tokens_BS: Tensor, max_length: int):
         B, S = tokens_BS.size()
@@ -239,6 +240,7 @@ class BatchInferenceEngine:
             coord_xy=coord_xy,
             size_hw=size_hw,
             img_scatter_info=img_scatter_info or None,
+            flex_attn_kernel_options=self.kernel_options or None,
         )
 
         hr_image_features = None
@@ -296,6 +298,7 @@ class BatchInferenceEngine:
                 coord_xy=xy_b2.to(self.model.dtype),
                 size_hw=hw_b2.to(self.model.dtype),
                 kv_cache=kv_cache,
+                flex_attn_kernel_options=self.kernel_options or None,
             )
 
             hit_stop_B = torch.isin(tokens_B1, stop_ids).any(dim=-1)

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 
 [[package]]
 name = "falcon-perception"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },
@@ -3973,27 +3973,27 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-win_amd64.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Close #7 

- Pass flex attention's kernel option for both Batch and Paged Inference engine.
- the demo script has option `--flex-attn-safe` that would set block size to 64 and `num_stages=1` explicitly for flex attention, potentially fix the OOM issue for gpu with lower shared memory (RTX3090 or A40).