### PR TITLE
Image shrink factor for anyup speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ outputs*/
 *.DS_Store
 dist/
 build/
+profiles/
+profile.sh

--- a/demo/perception_benchmark.py
+++ b/demo/perception_benchmark.py
@@ -177,9 +177,8 @@ def main(
     print("Warmup run ...")
     warmup_seq = sequences[0].copy()
     warmup_seq.request_idx = 0
-    with cuda_timed(reset_peak_memory=False) as warmup_timer:
-        with nvtx_range("Warmup"):
-            engine.generate([warmup_seq], sampling_params=sampling_params)
+    with cuda_timed(reset_peak_memory=False) as warmup_timer, nvtx_range("Warmup"):
+        engine.generate([warmup_seq], sampling_params=sampling_params)
     print(f"Warmup done in {warmup_timer.elapsed:.1f}s")
 
     profiler = None
@@ -204,15 +203,14 @@ def main(
         profiler.start()
 
     torch.cuda.reset_peak_memory_stats()
-    with cuda_timed() as timer:
-        with nvtx_range("Generate"):
-            engine.generate(
-                sequences,
-                sampling_params=sampling_params,
-                use_tqdm=True,
-                print_stats=True,
-                profiler=profiler,
-            )
+    with cuda_timed() as timer, nvtx_range("Generate"):
+        engine.generate(
+            sequences,
+            sampling_params=sampling_params,
+            use_tqdm=True,
+            print_stats=True,
+            profiler=profiler,
+        )
 
     if profiler is not None:
         profiler.stop()

--- a/demo/perception_benchmark.py
+++ b/demo/perception_benchmark.py
@@ -37,6 +37,7 @@ from falcon_perception import (
     setup_torch_config,
 )
 from falcon_perception.data import ImageProcessor, stream_samples_from_hf_dataset
+from falcon_perception.nvtx import nvtx_range
 from falcon_perception.paged_inference import (
     PagedInferenceEngine,
     SamplingParams,
@@ -110,6 +111,7 @@ def main(
     n_pages: int = 512,
     max_decode_steps_between_prefills: int = 8,
     hr_upsample_ratio: int = 8,
+    shrink_image: bool = True,
     profile: bool = False,
     profile_steps: int = 10,
     out_dir: str = "./outputs_dense/",
@@ -168,6 +170,7 @@ def main(
     sampling_params = SamplingParams(
         max_new_tokens, stop_token_ids=stop_token_ids,
         coord_dedup_threshold=0.01, hr_upsample_ratio=hr_upsample_ratio,
+        shrink_image=shrink_image,
     )
 
     # Warmup absorbs torch.compile JIT cost so the benchmark measures steady-state.
@@ -175,7 +178,8 @@ def main(
     warmup_seq = sequences[0].copy()
     warmup_seq.request_idx = 0
     with cuda_timed(reset_peak_memory=False) as warmup_timer:
-        engine.generate([warmup_seq], sampling_params=sampling_params)
+        with nvtx_range("Warmup"):
+            engine.generate([warmup_seq], sampling_params=sampling_params)
     print(f"Warmup done in {warmup_timer.elapsed:.1f}s")
 
     profiler = None
@@ -201,13 +205,14 @@ def main(
 
     torch.cuda.reset_peak_memory_stats()
     with cuda_timed() as timer:
-        engine.generate(
-            sequences,
-            sampling_params=sampling_params,
-            use_tqdm=True,
-            print_stats=True,
-            profiler=profiler,
-        )
+        with nvtx_range("Generate"):
+            engine.generate(
+                sequences,
+                sampling_params=sampling_params,
+                use_tqdm=True,
+                print_stats=True,
+                profiler=profiler,
+            )
 
     if profiler is not None:
         profiler.stop()

--- a/demo/perception_single.py
+++ b/demo/perception_single.py
@@ -136,14 +136,13 @@ def main(
         # Warmup absorbs torch.compile cost
         print("Warmup run ...")
         warmup_seqs = _make_sequences()
-        with cuda_timed(reset_peak_memory=False) as warmup_timer:
-            with nvtx_range("Warmup"):
-                engine.generate(
-                    warmup_seqs,
-                    sampling_params=sampling_params,
-                    use_tqdm=False,
-                    print_stats=False,
-                )
+        with cuda_timed(reset_peak_memory=False) as warmup_timer, nvtx_range("Warmup"):
+            engine.generate(
+                warmup_seqs,
+                sampling_params=sampling_params,
+                use_tqdm=False,
+                print_stats=False,
+            )
         print(f"Warmup done in {warmup_timer.elapsed:.1f}s")
 
         print("Running inference ...")

--- a/demo/perception_single.py
+++ b/demo/perception_single.py
@@ -27,6 +27,7 @@ from falcon_perception import (
     setup_torch_config,
 )
 from falcon_perception.data import load_image, stream_samples_from_hf_dataset
+from falcon_perception.nvtx import nvtx_range
 
 setup_torch_config()
 
@@ -136,22 +137,24 @@ def main(
         print("Warmup run ...")
         warmup_seqs = _make_sequences()
         with cuda_timed(reset_peak_memory=False) as warmup_timer:
-            engine.generate(
-                warmup_seqs,
-                sampling_params=sampling_params,
-                use_tqdm=False,
-                print_stats=False,
-            )
+            with nvtx_range("Warmup"):
+                engine.generate(
+                    warmup_seqs,
+                    sampling_params=sampling_params,
+                    use_tqdm=False,
+                    print_stats=False,
+                )
         print(f"Warmup done in {warmup_timer.elapsed:.1f}s")
 
         print("Running inference ...")
         sequences = _make_sequences()
-        engine.generate(
-            sequences,
-            sampling_params=sampling_params,
-            use_tqdm=True,
-            print_stats=True,
-        )
+        with nvtx_range("Generate"):
+            engine.generate(
+                sequences,
+                sampling_params=sampling_params,
+                use_tqdm=True,
+                print_stats=True,
+            )
 
         seq = sequences[0]
         aux = seq.output_aux

--- a/eval/pbench.py
+++ b/eval/pbench.py
@@ -149,6 +149,7 @@ def _run_split(
     min_dimension: int,
     max_new_tokens: int,
     hr_upsample_ratio: int,
+    shrink_image: bool = True,
 ) -> dict:
     """Run inference + F1 evaluation for one PBench split.
 
@@ -199,6 +200,7 @@ def _run_split(
         stop_token_ids=stop_ids,
         coord_dedup_threshold=0.01,
         hr_upsample_ratio=hr_upsample_ratio,
+        shrink_image=shrink_image,
     )
 
     # ── Inference ─────────────────────────────────────────────────────────────
@@ -306,6 +308,7 @@ def main(
     min_dimension: int = 256,
     max_dimension: int = 1024,
     hr_upsample_ratio: int = 8,
+    shrink_image: bool = True,
     out_dir: str = "./eval_results/pbench/",
 ):
     """Evaluate Falcon Perception on the PBench segmentation benchmark.
@@ -325,6 +328,7 @@ def main(
         min_dimension:    Minimum image edge before force-resize.
         max_dimension:    Target longest edge for force-resize (default: 1024).
         hr_upsample_ratio: High-resolution upsampling ratio for segmentation.
+        shrink_image:     Area-pool AnyUp RGB to output_size before encode (default: True).
         out_dir:          Directory for per-split JSON results. '' disables saving.
     """
     splits_to_run = SPLITS if split == "all" else [split]
@@ -374,6 +378,7 @@ def main(
             min_dimension=min_dimension,
             max_new_tokens=max_new_tokens,
             hr_upsample_ratio=hr_upsample_ratio,
+            shrink_image=shrink_image,
         )
         all_results.append(result)
 

--- a/falcon_perception/__init__.py
+++ b/falcon_perception/__init__.py
@@ -18,6 +18,9 @@ __all__ = [
     "get_tokenizer",
     "setup_torch_config",
     "cuda_timed",
+    "nvtx_range",
+    "is_nvtx_enabled",
+    "set_nvtx_enabled",
     "PERCEPTION_MODEL_ID",
     "PERCEPTION_300M_MODEL_ID",
     "OCR_MODEL_ID",
@@ -185,6 +188,15 @@ def setup_torch_config():
     torch._inductor.config.triton.cudagraphs = False
     torch._inductor.config.fx_graph_cache = True
     torch.set_float32_matmul_precision("high")
+
+
+# ── NVTX (re-export) ──────────────────────────────────────────────────
+
+from falcon_perception.nvtx import (  # noqa: E402
+    is_nvtx_enabled,
+    nvtx_range,
+    set_nvtx_enabled,
+)
 
 
 # ── Timing utility ────────────────────────────────────────────────────

--- a/falcon_perception/batch_inference.py
+++ b/falcon_perception/batch_inference.py
@@ -10,6 +10,7 @@ from falcon_perception.aux_output import AuxOutput
 from falcon_perception.data import ImageProcessor, load_images, tokenize_inputs, get_pos_thw, pad_sequences_left
 from falcon_perception.kv_cache import KVCacheBase
 from falcon_perception.model import FalconPerception, ImgScatterEntry
+from falcon_perception.nvtx import nvtx_range
 from falcon_perception.sampling import sample_token
 
 
@@ -230,24 +231,26 @@ class BatchInferenceEngine:
                 img_scatter_info.append(ImgScatterEntry(b, int(img_pos[0]), len(img_pos), h_v, w_v))
 
         # Prefill
-        logits_BSV, h_BSD = self.model(
-            tokens=tokens,  # Original sequence, no padding
-            rope_pos_t=pos_t,
-            rope_pos_hw=pos_hw,
-            attention_mask=attention_mask,
-            kv_cache=kv_cache,
-            pixel_values=pixel_values,
-            coord_xy=coord_xy,
-            size_hw=size_hw,
-            img_scatter_info=img_scatter_info or None,
-            flex_attn_kernel_options=self.kernel_options or None,
-        )
-
-        hr_image_features = None
-        if task == "segmentation":
-            hr_image_features = self.model.upsample_img_features(
-                h_BSD, pixel_values, img_scatter_info,
+        with nvtx_range("prefill"):
+            logits_BSV, h_BSD = self.model(
+                tokens=tokens,  # Original sequence, no padding
+                rope_pos_t=pos_t,
+                rope_pos_hw=pos_hw,
+                attention_mask=attention_mask,
+                kv_cache=kv_cache,
+                pixel_values=pixel_values,
+                coord_xy=coord_xy,
+                size_hw=size_hw,
+                img_scatter_info=img_scatter_info or None,
+                flex_attn_kernel_options=self.kernel_options or None,
             )
+
+            hr_image_features = None
+            if task == "segmentation":
+                with nvtx_range("upsample_img_features"):
+                    hr_image_features = self.model.upsample_img_features(
+                        h_BSD, pixel_values, img_scatter_info,
+                    )
 
         aux_outputs: list[AuxOutput] = [AuxOutput() for _ in range(B)]
         stop_token_ids = stop_token_ids or [self.tokenizer.eos_token_id]
@@ -292,14 +295,15 @@ class BatchInferenceEngine:
                     for i, b in enumerate(sample_w_segm.tolist()):
                         aux_outputs[b].append_segm(segm_embeds[i])
 
-            logits_BSV, h_BSD = self.model(
-                tokens=tokens_B1,
-                attention_mask=attention_mask,
-                coord_xy=xy_b2.to(self.model.dtype),
-                size_hw=hw_b2.to(self.model.dtype),
-                kv_cache=kv_cache,
-                flex_attn_kernel_options=self.kernel_options or None,
-            )
+            with nvtx_range("decode"):
+                logits_BSV, h_BSD = self.model(
+                    tokens=tokens_B1,
+                    attention_mask=attention_mask,
+                    coord_xy=xy_b2.to(self.model.dtype),
+                    size_hw=hw_b2.to(self.model.dtype),
+                    kv_cache=kv_cache,
+                    flex_attn_kernel_options=self.kernel_options or None,
+                )
 
             hit_stop_B = torch.isin(tokens_B1, stop_ids).any(dim=-1)
             should_stop_B = should_stop_B.logical_or(hit_stop_B)

--- a/falcon_perception/batch_inference.py
+++ b/falcon_perception/batch_inference.py
@@ -247,10 +247,9 @@ class BatchInferenceEngine:
 
             hr_image_features = None
             if task == "segmentation":
-                with nvtx_range("upsample_img_features"):
-                    hr_image_features = self.model.upsample_img_features(
-                        h_BSD, pixel_values, img_scatter_info,
-                    )
+                hr_image_features = self.model.upsample_img_features(
+                    h_BSD, pixel_values, img_scatter_info,
+                )
 
         aux_outputs: list[AuxOutput] = [AuxOutput() for _ in range(B)]
         stop_token_ids = stop_token_ids or [self.tokenizer.eos_token_id]

--- a/falcon_perception/batch_inference.py
+++ b/falcon_perception/batch_inference.py
@@ -7,7 +7,14 @@ from torch import Tensor
 
 from falcon_perception.attention import create_batch_attention_mask
 from falcon_perception.aux_output import AuxOutput
-from falcon_perception.data import ImageProcessor, load_images, tokenize_inputs, get_pos_thw, pad_sequences_left
+from falcon_perception.data import (
+    ImageProcessor,
+    anyup_canvas_size,
+    get_pos_thw,
+    load_images,
+    pad_sequences_left,
+    tokenize_inputs,
+)
 from falcon_perception.kv_cache import KVCacheBase
 from falcon_perception.model import FalconPerception, ImgScatterEntry
 from falcon_perception.nvtx import nvtx_range
@@ -57,8 +64,13 @@ def process_batch_and_generate(
     assert tokenizer.pad_token_id is not None, "tokenizer.pad_token_id must be set for batching"
     padded_np = pad_sequences_left(all_input_ids, tokenizer.pad_token_id)
 
+    max_h = max(img.shape[1] for img in all_selected_images)
+    max_w = max(img.shape[2] for img in all_selected_images)
+    canvas, _ = anyup_canvas_size(
+        max_h, max_w, patch_size=patch_size, max_size=max_dimension,
+    )
     processed = processor_local.batch_images_with_mask(
-        all_selected_images, max_dimension, max_dimension
+        all_selected_images, canvas, canvas
     )
     assert processed is not None
     pos_t_np, pos_hw_np = get_pos_thw(
@@ -183,6 +195,8 @@ class BatchInferenceEngine:
         seed: int | None = None,
         coord_dedup_threshold: float = 0.01,
         task: str = "segmentation",
+        hr_upsample_ratio: int = 8,
+        shrink_image: bool = True,
     ):
         device = tokens.device
         rng = torch.Generator(device).manual_seed(seed) if seed is not None else None
@@ -247,8 +261,12 @@ class BatchInferenceEngine:
 
             hr_image_features = None
             if task == "segmentation":
+                _, _, H, W, _ = pixel_values.shape
+                output_size = (H // ps * hr_upsample_ratio, W // ps * hr_upsample_ratio)
                 hr_image_features = self.model.upsample_img_features(
                     h_BSD, pixel_values, img_scatter_info,
+                    output_size=output_size,
+                    shrink_image=shrink_image,
                 )
 
         aux_outputs: list[AuxOutput] = [AuxOutput() for _ in range(B)]
@@ -308,18 +326,19 @@ class BatchInferenceEngine:
             should_stop_B = should_stop_B.logical_or(hit_stop_B)
 
         # Batch-finalize segmentation masks per image.
-        # hr_image_features are at the padded canvas size (max_dim x max_dim).
-        # Crop each to the actual image extent (remove batch padding) so masks
-        # are produced at the model's processing resolution, not the padded size.
+        # hr_image_features are at AnyUp output_size; crop to the unpadded
+        # image extent scaled by hr_upsample_ratio / patch_size.
         for b in range(B):
             hr_feat_b = None
             if hr_image_features is not None:
-                hr_feat_b = hr_image_features[b]  # (D, H_pad, W_pad)
-                mask_b = pixel_mask[b, 0]        # (H_pad, W_pad)
+                hr_feat_b = hr_image_features[b]  # (D, out_H, out_W)
+                mask_b = pixel_mask[b, 0]        # (H_canvas, W_canvas)
                 h_actual = int(mask_b.any(dim=1).sum())
                 w_actual = int(mask_b.any(dim=0).sum())
-                if h_actual > 0 and w_actual > 0:
-                    hr_feat_b = hr_feat_b[:, :h_actual, :w_actual]
+                h_px = (h_actual // ps) * hr_upsample_ratio
+                w_px = (w_actual // ps) * hr_upsample_ratio
+                if h_px > 0 and w_px > 0:
+                    hr_feat_b = hr_feat_b[:, :h_px, :w_px]
             aux_outputs[b].finalize(
                 hr_image_features=hr_feat_b,
                 task=task,

--- a/falcon_perception/data.py
+++ b/falcon_perception/data.py
@@ -21,6 +21,63 @@ from PIL import Image
 IMAGE_MEAN = [0.5, 0.5, 0.5]
 IMAGE_STD = [0.5, 0.5, 0.5]
 
+# AnyUp canvas / output are snapped to this grid so torch.compile sees a
+# handful of shapes (128, 256, ..., 1024) instead of one graph per native size.
+ANYUP_SIZE_STEP = 128
+ANYUP_SIZE_MIN = 128
+ANYUP_SIZE_MAX = 1024
+
+
+def snap_image_size(
+    size: int,
+    *,
+    step: int = ANYUP_SIZE_STEP,
+    min_size: int = ANYUP_SIZE_MIN,
+    max_size: int = ANYUP_SIZE_MAX,
+) -> int:
+    """Round *size* up to a multiple of *step*, clamped to [*min_size*, *max_size*]."""
+    size = min(max(int(size), min_size), max_size)
+    snapped = ((size + step - 1) // step) * step
+    return min(max(snapped, min_size), max_size)
+
+
+def anyup_canvas_size(
+    height: int,
+    width: int,
+    *,
+    patch_size: int = 16,
+    upsample_ratio: int = 8,
+    step: int = ANYUP_SIZE_STEP,
+    min_size: int = ANYUP_SIZE_MIN,
+    max_size: int = ANYUP_SIZE_MAX,
+) -> tuple[int, tuple[int, int]]:
+    """Square AnyUp canvas and matching HR output, both on the *step* grid.
+
+    Snaps the *output* up to a multiple of *step* (min *min_size*, max
+    ``max_size * upsample_ratio / patch_size``), then derives the canvas
+    as ``output * patch_size / upsample_ratio``.  With the defaults
+    (ps=16, ratio=8, step=128) the allowed pairs are::
+
+        canvas 256 → output 128
+        canvas 512 → output 256
+        canvas 768 → output 384
+        canvas 1024 → output 512
+
+    A 768 image therefore runs at 768 / 384 instead of always 1024 / 512.
+    Four compile shapes instead of one graph per native resolution.
+    """
+    need = max(height, width)
+    need = ((need + patch_size - 1) // patch_size) * patch_size
+    need = min(need, max_size)
+
+    native_out = need // patch_size * upsample_ratio
+    out_max = max_size // patch_size * upsample_ratio
+    out = snap_image_size(
+        native_out, step=step, min_size=min(min_size, out_max), max_size=out_max,
+    )
+    canvas = out * patch_size // upsample_ratio
+    return canvas, (out, out)
+
 
 # ── Image I/O ──────────────────────────────────────────────────────────
 

--- a/falcon_perception/mlx/batch_inference.py
+++ b/falcon_perception/mlx/batch_inference.py
@@ -36,7 +36,12 @@ from falcon_perception.mlx.kv_cache import KVCache
 from falcon_perception.mlx.model import FalconPerception, ImgScatterEntry
 from falcon_perception.mlx.sampling import sample_token
 from falcon_perception.data import (
-    ImageProcessor, load_images, tokenize_inputs, get_pos_thw, pad_sequences_left,
+    ImageProcessor,
+    anyup_canvas_size,
+    get_pos_thw,
+    load_images,
+    pad_sequences_left,
+    tokenize_inputs,
 )
 
 
@@ -82,9 +87,17 @@ def process_batch_and_generate(
 
     padded_np = pad_sequences_left(all_input_ids, tokenizer.pad_token_id)
 
-    processed = processor_local.batch_images_with_mask(
-        all_selected_images, max_dimension, max_dimension,
-    )
+    if all_selected_images:
+        max_h = max(img.shape[1] for img in all_selected_images)
+        max_w = max(img.shape[2] for img in all_selected_images)
+        canvas, _ = anyup_canvas_size(
+            max_h, max_w, patch_size=patch_size, max_size=max_dimension,
+        )
+        processed = processor_local.batch_images_with_mask(
+            all_selected_images, canvas, canvas,
+        )
+    else:
+        processed = None
     assert processed is not None
 
     pos_t_np, pos_hw_np = get_pos_thw(
@@ -271,6 +284,8 @@ class BatchInferenceEngine:
         seed: int | None = None,
         coord_dedup_threshold: float = 0.01,
         task: str = "segmentation",
+        hr_upsample_ratio: int = 8,
+        shrink_image: bool = True,
     ):
         if seed is not None:
             mx.random.seed(seed)
@@ -335,8 +350,12 @@ class BatchInferenceEngine:
 
         hr_image_features = None
         if task == "segmentation" and img_scatter_info and self.model_args.perception_heads:
+            _, _, H, W, _ = pixel_values.shape
+            output_size = (H // ps * hr_upsample_ratio, W // ps * hr_upsample_ratio)
             hr_image_features = self.model.upsample_img_features(
                 h_BSD, pixel_values, img_scatter_info,
+                output_size=output_size,
+                shrink_image=shrink_image,
             )
 
         aux_outputs = [AuxOutput() for _ in range(B)]
@@ -431,7 +450,8 @@ class BatchInferenceEngine:
             prefill_np[b, L:L + len(gen)] = gen
         padded_tokens_BS = mx.array(prefill_np)
 
-        # Finalize
+        # Finalize: hr features are at AnyUp output_size; crop to the unpadded
+        # image extent scaled by hr_upsample_ratio / patch_size.
         for b in range(B):
             hr_feat_b = None
             if hr_image_features is not None:
@@ -439,8 +459,10 @@ class BatchInferenceEngine:
                 mask_b = pixel_mask[b, 0]
                 h_actual = int(np.array(mx.any(mask_b, axis=1).astype(mx.int32).sum()))
                 w_actual = int(np.array(mx.any(mask_b, axis=0).astype(mx.int32).sum()))
-                if h_actual > 0 and w_actual > 0:
-                    hr_feat_b = hr_feat_b[:, :h_actual, :w_actual]
+                h_px = (h_actual // ps) * hr_upsample_ratio
+                w_px = (w_actual // ps) * hr_upsample_ratio
+                if h_px > 0 and w_px > 0:
+                    hr_feat_b = hr_feat_b[:, :h_px, :w_px]
             aux_outputs[b].finalize(
                 hr_image_features=hr_feat_b,
                 task=task,

--- a/falcon_perception/mlx/model.py
+++ b/falcon_perception/mlx/model.py
@@ -19,7 +19,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from falcon_perception import ModelArgs
-from falcon_perception.mlx.anyup import AnyUp
+from falcon_perception.mlx.anyup import AnyUp, _pool_to
 from falcon_perception.mlx.kv_cache import KVCache
 from falcon_perception.mlx.rope import (
     apply_3d_rotary_emb,
@@ -383,7 +383,14 @@ class FalconPerception(nn.Module):
         h_valid: int,
         w_valid: int,
         output_size=None,
+        shrink_image: bool = True,
     ):
+        """Upsample image features for a single image.
+
+        ``shrink_image`` area-pools RGB to ``output_size`` before AnyUp when
+        dims divide evenly (faster; small quality tradeoff). Callers bucket
+        the canvas via ``anyup_canvas_size`` so a 768 image yields output 384.
+        """
         ps = self.args.spatial_patch_size
         _, H, W, _ = pixel_values_THWC.shape
         h_patch, w_patch = H // ps, W // ps
@@ -408,6 +415,16 @@ class FalconPerception(nn.Module):
         if output_size is None:
             output_size = (H, W)
 
+        out_H, out_W = output_size
+        if (
+            shrink_image
+            and H > out_H
+            and W > out_W
+            and H % out_H == 0
+            and W % out_W == 0
+        ):
+            image = _pool_to(image, (out_H, out_W))
+
         hr_img_features = self.itok_upsampler(
             images=image,
             features=lr_img_features,
@@ -421,6 +438,7 @@ class FalconPerception(nn.Module):
         pixel_values_NTHWC,
         img_scatter_info: list[ImgScatterEntry],
         output_size=None,
+        shrink_image: bool = True,
     ):
         hr_parts = []
         for i, entry in enumerate(img_scatter_info):
@@ -431,6 +449,7 @@ class FalconPerception(nn.Module):
                 h_valid=entry.h_valid_patches,
                 w_valid=entry.w_valid_patches,
                 output_size=output_size,
+                shrink_image=shrink_image,
             )
             hr_parts.append(hr_i)
         return mx.stack(hr_parts, axis=0)

--- a/falcon_perception/model.py
+++ b/falcon_perception/model.py
@@ -525,6 +525,7 @@ class FalconPerception(nn.Module):
         pred = pred * (max_size - min_size) + min_size
         return torch.pow(2.0, pred)
 
+    @nvtx_range("upsample_single_img_features")
     def upsample_single_img_features(
         self,
         h_SD: T,
@@ -592,16 +593,15 @@ class FalconPerception(nn.Module):
         upsampler_attn_mask = build_upsampler_block_mask(
             out_H, out_W, h_patch, w_patch, device=image.device,
         )
-        # NVTX outside compiled AnyUp.forward — avoids Dynamo graph breaks.
-        with nvtx_range("anyup"):
-            hr_img_features = self.itok_upsampler(
-                images=image,
-                features=lr_img_features,
-                attn_mask=upsampler_attn_mask,
-                output_size=output_size,
-            )
+        hr_img_features = self.itok_upsampler(
+            images=image,
+            features=lr_img_features,
+            attn_mask=upsampler_attn_mask,
+            output_size=output_size,
+        )
         return hr_img_features[0] # (D, out_H, out_W)
 
+    @nvtx_range("upsample_img_features")
     def upsample_img_features(
         self,
         h_BSD: T,

--- a/falcon_perception/model.py
+++ b/falcon_perception/model.py
@@ -581,6 +581,8 @@ class FalconPerception(nn.Module):
         # resolution. The shrink factor is ``spatial_patch_size // ratio`` (2 for
         # the default ps=16, ratio=8), so this is exact only when it divides
         # evenly — otherwise keep the original image and let AnyUp pool.
+        # Callers bucket the canvas via ``anyup_canvas_size`` (128-multiple,
+        # min 128, max ``max_image_size``) so a 768 image yields output 384.
         if (
             shrink_image
             and H > out_H

--- a/falcon_perception/model.py
+++ b/falcon_perception/model.py
@@ -16,13 +16,14 @@ from torch.nn.attention.flex_attention import (
 )
 
 from falcon_perception import ModelArgs
-from falcon_perception.anyup import AnyUp, build_upsampler_block_mask
+from falcon_perception.anyup import AnyUp, _pool_to, build_upsampler_block_mask
 from falcon_perception.attention import (
     compiled_flex_attn_decode,
     compiled_flex_attn_prefill,
     offset_mask_mod,
 )
 from falcon_perception.kv_cache import KVCacheBase
+from falcon_perception.nvtx import nvtx_range
 from falcon_perception.rope import (
     apply_3d_rotary_emb,
     apply_golden_freqs_cis_to_visual_pos,
@@ -532,6 +533,7 @@ class FalconPerception(nn.Module):
         h_valid: int,
         w_valid: int,
         output_size: tuple[int, int] | None = None,
+        shrink_image: bool = True,
     ) -> T:
         """Upsample image features for a single image.
 
@@ -542,6 +544,8 @@ class FalconPerception(nn.Module):
             h_valid, w_valid: valid patch grid size (before padding).
             output_size: ``(out_H, out_W)``.  *None* = full pixel resolution.
                 ``(h_patch, w_patch)`` skips AnyUp entirely.
+            shrink_image: if True, area-pool RGB to ``output_size`` before AnyUp
+                when dims divide evenly (faster; small quality tradeoff).
         Returns: ``(D, H, W)`` high-res features.
         """
         ps = self.args.spatial_patch_size
@@ -567,15 +571,35 @@ class FalconPerception(nn.Module):
             output_size = (H, W)
 
         out_H, out_W = output_size
+
+        # AnyUp area-pools its query features down to ``output_size`` and its key
+        # features down to the ``(h_patch, w_patch)`` grid, so every pixel of
+        # ``image`` above ``output_size`` is encoded (at 1x1 conv, i.e. per-pixel)
+        # only to be averaged away. Shrink up front instead: the image / query /
+        # key encoders then all run at ``output_size`` rather than at full
+        # resolution. The shrink factor is ``spatial_patch_size // ratio`` (2 for
+        # the default ps=16, ratio=8), so this is exact only when it divides
+        # evenly — otherwise keep the original image and let AnyUp pool.
+        if (
+            shrink_image
+            and H > out_H
+            and W > out_W
+            and H % out_H == 0
+            and W % out_W == 0
+        ):
+            image = _pool_to(image, (out_H, out_W))
+
         upsampler_attn_mask = build_upsampler_block_mask(
             out_H, out_W, h_patch, w_patch, device=image.device,
         )
-        hr_img_features = self.itok_upsampler(
-            images=image,
-            features=lr_img_features,
-            attn_mask=upsampler_attn_mask,
-            output_size=output_size,
-        )
+        # NVTX outside compiled AnyUp.forward — avoids Dynamo graph breaks.
+        with nvtx_range("anyup"):
+            hr_img_features = self.itok_upsampler(
+                images=image,
+                features=lr_img_features,
+                attn_mask=upsampler_attn_mask,
+                output_size=output_size,
+            )
         return hr_img_features[0] # (D, out_H, out_W)
 
     def upsample_img_features(
@@ -584,6 +608,7 @@ class FalconPerception(nn.Module):
         pixel_values_NTHWC: list[T] | T,
         img_scatter_info: list[ImgScatterEntry],
         output_size: tuple[int, int] | None = None,
+        shrink_image: bool = True,
     ) -> T:
         """Upsample per-image, then stack.  Keeps peak memory bounded.
 
@@ -602,6 +627,7 @@ class FalconPerception(nn.Module):
                 h_valid=entry.h_valid_patches,
                 w_valid=entry.w_valid_patches,
                 output_size=output_size,
+                shrink_image=shrink_image,
             )
             hr_parts.append(hr_i)
         return torch.stack(hr_parts, dim=0)

--- a/falcon_perception/nvtx.py
+++ b/falcon_perception/nvtx.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2025 Technology Innovation Institute (TII), UAE.
+"""Optional NVTX ranges for Nsight profiling.
+
+Enable with the single flag ``FALCON_NVTX=1`` (or call ``set_nvtx_enabled(True)``).
+Ranges are pushed only from Python call sites *outside* ``torch.compile`` /
+CUDA-graph capture regions, so enabling them does not introduce Dynamo graph
+breaks or corrupt captured graphs.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager, nullcontext
+from typing import Iterator
+
+__all__ = [
+    "is_nvtx_enabled",
+    "set_nvtx_enabled",
+    "nvtx_range",
+]
+
+
+def _env_enabled() -> bool:
+    v = os.environ.get("FALCON_NVTX", "0")
+    return v.lower() not in ("0", "false", "no", "off", "")
+
+
+_NVTX_ENABLED: bool = _env_enabled()
+
+
+def is_nvtx_enabled() -> bool:
+    return _NVTX_ENABLED
+
+
+def set_nvtx_enabled(enabled: bool) -> None:
+    """Toggle NVTX annotations at runtime (overrides ``FALCON_NVTX``)."""
+    global _NVTX_ENABLED
+    _NVTX_ENABLED = bool(enabled)
+
+
+@contextmanager
+def _nvtx_range_impl(name: str) -> Iterator[None]:
+    import torch
+
+    torch.cuda.nvtx.range_push(name)
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
+
+
+def nvtx_range(name: str):
+    """Context manager that emits an NVTX range when annotations are enabled.
+
+    When disabled, returns a no-op ``nullcontext`` (no generator overhead).
+    Safe to use around compiled / CUDA-graph call sites — never call this
+    *inside* a ``torch.compile``'d function body.
+    """
+    if not _NVTX_ENABLED:
+        return nullcontext()
+    return _nvtx_range_impl(name)

--- a/falcon_perception/nvtx.py
+++ b/falcon_perception/nvtx.py
@@ -5,13 +5,21 @@ Enable with the single flag ``FALCON_NVTX=1`` (or call ``set_nvtx_enabled(True)`
 Ranges are pushed only from Python call sites *outside* ``torch.compile`` /
 CUDA-graph capture regions, so enabling them does not introduce Dynamo graph
 breaks or corrupt captured graphs.
+
+``nvtx_range`` is a :class:`~contextlib.ContextDecorator`, so both forms work::
+
+    with nvtx_range("prefill"):
+        ...
+
+    @nvtx_range("decode")
+    def decode_step(...):
+        ...
 """
 
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager, nullcontext
-from typing import Iterator
+from contextlib import ContextDecorator
 
 __all__ = [
     "is_nvtx_enabled",
@@ -38,24 +46,29 @@ def set_nvtx_enabled(enabled: bool) -> None:
     _NVTX_ENABLED = bool(enabled)
 
 
-@contextmanager
-def _nvtx_range_impl(name: str) -> Iterator[None]:
-    import torch
+class nvtx_range(ContextDecorator):
+    """NVTX range as ``with nvtx_range("name"):`` or ``@nvtx_range("name")``.
 
-    torch.cuda.nvtx.range_push(name)
-    try:
-        yield
-    finally:
-        torch.cuda.nvtx.range_pop()
-
-
-def nvtx_range(name: str):
-    """Context manager that emits an NVTX range when annotations are enabled.
-
-    When disabled, returns a no-op ``nullcontext`` (no generator overhead).
-    Safe to use around compiled / CUDA-graph call sites — never call this
-    *inside* a ``torch.compile``'d function body.
+    No-op when annotations are disabled. The enabled check runs on enter/exit,
+    so ``set_nvtx_enabled`` applies to both forms. Safe to use around compiled
+    / CUDA-graph call sites — never call this *inside* a ``torch.compile``'d
+    function body.
     """
-    if not _NVTX_ENABLED:
-        return nullcontext()
-    return _nvtx_range_impl(name)
+
+    def __init__(self, name: str):
+        self._name = name
+        self._pushed = False
+
+    def __enter__(self):
+        if _NVTX_ENABLED:
+            import torch
+            torch.cuda.nvtx.range_push(self._name)
+            self._pushed = True
+        return self
+
+    def __exit__(self, *exc):
+        if self._pushed:
+            import torch
+            torch.cuda.nvtx.range_pop()
+            self._pushed = False
+        return None

--- a/falcon_perception/paged_inference.py
+++ b/falcon_perception/paged_inference.py
@@ -24,6 +24,7 @@ from falcon_perception.data import (
     tokenize_inputs,
 )
 from falcon_perception.model import FalconPerception, ImgScatterEntry
+from falcon_perception.nvtx import nvtx_range
 from falcon_perception.paged_attention import PagedKVCache
 from falcon_perception.sampling import sample_token
 
@@ -67,6 +68,9 @@ class SamplingParams:
     segmentation_threshold: float = 0.3
     coord_dedup_threshold: float = 0.00
     hr_upsample_ratio: int = 8
+    # When True, area-pool the AnyUp RGB input down to ``output_size`` before
+    # the image encoder (default). Disable to match the original full-res path.
+    shrink_image: bool = True
 
 
 @dataclass
@@ -230,7 +234,7 @@ def process_sampling_params(
 # Pick the first tier whose threshold <= your GPU.
 # Tiers are searched large-to-small so the biggest match wins.
 _GPU_PRESETS: list[tuple[int, dict]] = [
-    (79, dict(n_pages=1024,  page_size=128, max_batch_size=64, prefill_length_limit=32768, max_hr_cache_entries=256)),
+    (79, dict(n_pages=896,  page_size=128, max_batch_size=64, prefill_length_limit=32768, max_hr_cache_entries=256)),
     (47, dict(n_pages=512,  page_size=128, max_batch_size=32, prefill_length_limit=16384, max_hr_cache_entries=128)),
     (23, dict(n_pages=256,  page_size=128, max_batch_size=16,  prefill_length_limit=8192,  max_hr_cache_entries=64)),
     (15, dict(n_pages=128,  page_size=128, max_batch_size=8,  prefill_length_limit=8192,  max_hr_cache_entries=32)),
@@ -589,6 +593,7 @@ class PagedInferenceEngine:
                     h_valid=h_valid,
                     w_valid=w_valid,
                     output_size=output_size,
+                    shrink_image=seq.sampling_params.shrink_image,
                 )
 
                 # Crop to original (unpadded) pixel dimensions.
@@ -606,6 +611,12 @@ class PagedInferenceEngine:
                     seq.hr_image_features = gpu_futures[id(seq)]
 
     def prefill_sequences(self, sequences: list[Sequence]):
+        # NVTX wraps the whole engine prefill step (outside compiled regions /
+        # CUDA-graph capture). Nested "anyup" ranges fire from upsample calls.
+        with nvtx_range("prefill"):
+            self._prefill_sequences_impl(sequences)
+
+    def _prefill_sequences_impl(self, sequences: list[Sequence]):
         # NOTE: there are two kind of positional indices
         # 1. `input_pos` which count the token indices in the sequence so far
         # 2. `input_thw` which is the one used for 1+2D golden gate rope
@@ -1033,6 +1044,12 @@ class PagedInferenceEngine:
 
     def decode_step(self, sequences: list[Sequence]):
         """Sync-free decode step — no GPU→CPU reads on the hot path."""
+        # NVTX outside CUDA-graph capture/replay body — wraps graph.replay()
+        # without baking markers into the captured graph.
+        with nvtx_range("decode"):
+            self._decode_step_impl(sequences)
+
+    def _decode_step_impl(self, sequences: list[Sequence]):
         logits_BSV, h_BSD = self._decode_forward(sequences)
 
         next_token, logits, probs = sample_token(

--- a/falcon_perception/paged_inference.py
+++ b/falcon_perception/paged_inference.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 
 from falcon_perception.aux_output import AuxOutput
 from falcon_perception.data import (
+    anyup_canvas_size,
     get_pos_thw_single,
     load_image,
     resize_image_if_necessary,
@@ -576,15 +577,19 @@ class PagedInferenceEngine:
                 h_valid = seq.image_tensor.shape[1] // ps
                 w_valid = seq.image_tensor.shape[2] // ps
 
-                # Re-pad to square max_image_size for AnyUp training consistency.
+                # Square AnyUp canvas: snap output (and thus canvas) onto the
+                # 128 grid in [128, max_image_size]. A 768 image with ratio=8
+                # runs at 768 / 384 instead of always 1024 / 512.
                 pv = pixel_values_list[img_idx]  # (T, H_native, W_native, C)
-                target = ((seq.max_image_size + ps - 1) // ps) * ps
                 _, h_cur, w_cur, _ = pv.shape
+                target, output_size = anyup_canvas_size(
+                    h_cur, w_cur,
+                    patch_size=ps,
+                    upsample_ratio=ratio,
+                    max_size=seq.max_image_size,
+                )
                 if h_cur < target or w_cur < target:
                     pv = F.pad(pv, (0, 0, 0, target - w_cur, 0, target - h_cur))
-
-                target_patches = target // ps
-                output_size = (target_patches * ratio, target_patches * ratio)
 
                 hr_feat = self.model.upsample_single_img_features(
                     seq_h,

--- a/falcon_perception/paged_inference.py
+++ b/falcon_perception/paged_inference.py
@@ -234,7 +234,7 @@ def process_sampling_params(
 # Pick the first tier whose threshold <= your GPU.
 # Tiers are searched large-to-small so the biggest match wins.
 _GPU_PRESETS: list[tuple[int, dict]] = [
-    (79, dict(n_pages=896,  page_size=128, max_batch_size=64, prefill_length_limit=32768, max_hr_cache_entries=256)),
+    (79, dict(n_pages=1024,  page_size=128, max_batch_size=64, prefill_length_limit=32768, max_hr_cache_entries=256)),
     (47, dict(n_pages=512,  page_size=128, max_batch_size=32, prefill_length_limit=16384, max_hr_cache_entries=128)),
     (23, dict(n_pages=256,  page_size=128, max_batch_size=16,  prefill_length_limit=8192,  max_hr_cache_entries=64)),
     (15, dict(n_pages=128,  page_size=128, max_batch_size=8,  prefill_length_limit=8192,  max_hr_cache_entries=32)),
@@ -610,13 +610,10 @@ class PagedInferenceEngine:
                 if seq._hr_cache_hit:
                     seq.hr_image_features = gpu_futures[id(seq)]
 
+    # NVTX wraps the whole engine prefill step (outside compiled regions /
+    # CUDA-graph capture). Nested upsample ranges fire from upsample calls.
+    @nvtx_range("prefill")
     def prefill_sequences(self, sequences: list[Sequence]):
-        # NVTX wraps the whole engine prefill step (outside compiled regions /
-        # CUDA-graph capture). Nested "anyup" ranges fire from upsample calls.
-        with nvtx_range("prefill"):
-            self._prefill_sequences_impl(sequences)
-
-    def _prefill_sequences_impl(self, sequences: list[Sequence]):
         # NOTE: there are two kind of positional indices
         # 1. `input_pos` which count the token indices in the sequence so far
         # 2. `input_thw` which is the one used for 1+2D golden gate rope
@@ -1042,14 +1039,11 @@ class PagedInferenceEngine:
         return logits_BSV, h_BSD
 
 
+    # NVTX outside CUDA-graph capture/replay body — wraps graph.replay()
+    # without baking markers into the captured graph.
+    @nvtx_range("decode")
     def decode_step(self, sequences: list[Sequence]):
         """Sync-free decode step — no GPU→CPU reads on the hot path."""
-        # NVTX outside CUDA-graph capture/replay body — wraps graph.replay()
-        # without baking markers into the captured graph.
-        with nvtx_range("decode"):
-            self._decode_step_impl(sequences)
-
-    def _decode_step_impl(self, sequences: list[Sequence]):
         logits_BSV, h_BSD = self._decode_forward(sequences)
 
         next_token, logits, probs = sample_token(


### PR DESCRIPTION
**Observation:**
For default settings of upsample_factor=8, patch_size=16, max_image_size=1024, 
in paged inference engine: input image is padded to max_image_size before being sent to AnyUp. 
In Anyup, although, after query encoder anyways the image is pooled to output image size (which is 16*8 = 512). 

**Goal:**
Anyup time is almost the same as prefill time for certain image dimensions. Can we save on some anyup time?

**Question:**
What if we pool image to output_size **before** sending to AnyUp? : Will the result quality still be acceptable?

**Results:**
 Anyup runtimes before and after: 
<img width="856" height="298" alt="image" src="https://github.com/user-attachments/assets/e6d364b1-4bd7-4e31-b76f-6eea1a9d2ef9" />

<img width="833" height="401" alt="image" src="https://github.com/user-attachments/assets/bb953a09-08a9-4b28-bce2-31dc03755b36" />

<img width="776" height="490" alt="image" src="https://github.com/user-attachments/assets/d29a5f50-4a57-464d-b1c3-49299e6e3207" />


**Some pbench dense result samples:**
<img width="406" height="227" alt="image" src="https://github.com/user-attachments/assets/992c8c4e-c31a-49c2-9ad1-fa86e65e0eda" />
<img width="433" height="225" alt="image" src="https://github.com/user-attachments/assets/09c5ad5a-e220-424d-8f6e-b71a557c2f60" />

