### PR TITLE
batch sequence output transfers to CPU

### DIFF
--- a/falcon_perception/paged_inference.py
+++ b/falcon_perception/paged_inference.py
@@ -168,15 +168,21 @@ class Sequence:
 
     @property
     def output_ids(self):
-        return torch.tensor(self._output_ids, dtype=torch.int64)
+        if not self._output_ids:
+            return torch.empty(0, dtype=torch.int64, device="cpu")
+        return torch.stack(self._output_ids).to(device="cpu", dtype=torch.int64).detach()
 
     @property
     def output_logits(self):
-        return torch.tensor(self._output_logits, dtype=torch.float32)
+        if not self._output_logits:
+            return torch.empty(0, dtype=torch.float32, device="cpu")
+        return torch.stack(self._output_logits).to(device="cpu", dtype=torch.float32).detach()
 
     @property
     def output_probs(self):
-        return torch.tensor(self._output_probs, dtype=torch.float32)
+        if not self._output_probs:
+            return torch.empty(0, dtype=torch.float32, device="cpu")
+        return torch.stack(self._output_probs).to(device="cpu", dtype=torch.float32).detach()
 
     @property
     def input_length(self):

--- a/tests/test_sequence_outputs.py
+++ b/tests/test_sequence_outputs.py
@@ -1,0 +1,56 @@
+import unittest
+
+import torch
+
+from falcon_perception.paged_inference import Sequence
+
+
+class SequenceOutputTest(unittest.TestCase):
+    def test_output_contract_without_scalar_extraction(self):
+        devices = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+        for device in devices:
+            for count in (0, 1, 17):
+                with self.subTest(device=device, count=count):
+                    seq = Sequence(text="", image=None)
+                    ids = torch.arange(count, device=device)
+                    logits = torch.linspace(
+                        -4, 4, count, device=device, dtype=torch.float16
+                    )
+                    probs = torch.linspace(
+                        0, 1, count, device=device, dtype=torch.bfloat16
+                    )
+                    logits.requires_grad_()
+                    probs.requires_grad_()
+                    seq._output_ids = list(ids.unbind())
+                    seq._output_logits = list(logits.unbind())
+                    seq._output_probs = list(probs.unbind())
+                    seq.input_ids = torch.tensor([99, 100])
+                    with torch.profiler.profile(
+                        activities=[torch.profiler.ProfilerActivity.CPU]
+                    ) as profile:
+                        outputs = (seq.output_ids, seq.output_logits, seq.output_probs)
+                    scalar_calls = sum(
+                        e.count
+                        for e in profile.key_averages()
+                        if e.key == "aten::_local_scalar_dense"
+                    )
+                    self.assertEqual(scalar_calls, 0)
+                    for actual, expected in zip(
+                        outputs, (ids.cpu(), logits.float().cpu(), probs.float().cpu())
+                    ):
+                        self.assertEqual(actual.device.type, "cpu")
+                        self.assertFalse(actual.requires_grad)
+                        self.assertEqual(actual.dtype, expected.dtype)
+                        self.assertTrue(torch.equal(actual, expected))
+                    self.assertTrue(
+                        torch.equal(
+                            seq.total_token_ids, torch.cat((seq.input_ids, ids.cpu()))
+                        )
+                    )
+                    if count:
+                        outputs[0][0] = -1
+                        self.assertEqual(seq.output_ids[0].item(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`Sequence.output_ids`, `output_logits` and `output_probs` construct CPU tensors from lists of GPU scalar tensors. This extracts each scalar individually, adding overhead when retrieving longer outputs. Stacking each field on the GPU before transferring it to CPU removes these individual scalar extractions

**Measured on an A10G**
> Retrieving all three fields, median of 11 repetitions after warmup:

Tokens | Current | Batched transfer
-- | -- | --
64 | 1.940 ms | 0.221 ms
512 | 17.713 ms | 1.000 ms
4,096 | 141.345 ms | 7.350 ms

</div></div></div>